### PR TITLE
bugfix: don't mmap `/dev/mem` if `open()` fails

### DIFF
--- a/lib/allwinner-r8.js
+++ b/lib/allwinner-r8.js
@@ -76,6 +76,7 @@ AllwinnerR8.prototype.open = function(callback) {
   fs.open('/dev/mem', 'rs+', function(err, fd) {
     if (err) {
       callback(err);
+      return;
     }
 
     this._fd = fd;


### PR DESCRIPTION
This fixes the segmentation fault mentioned in #6 