### PR TITLE
Change i2cRead/i2cWrite from bus 1 to 2

### DIFF
--- a/lib/chip-io.js
+++ b/lib/chip-io.js
@@ -190,7 +190,7 @@ ChipIO.prototype.i2cWrite = function(address, register, data) {
 
   debug('i2cWrite', address, register, data);
 
-  var i2c = new I2C(1, address);
+  var i2c = new I2C(2, address);
 
   if (typeof(data) === 'number') {
     data = [data];
@@ -242,7 +242,7 @@ ChipIO.prototype.i2cReadOnce = function(address, register, size, handler) {
 
   debug('i2cReadOnce', address, register, size, handler);
 
-  var i2c = new I2C(1, address);
+  var i2c = new I2C(2, address);
 
   i2c.open(function(err) {
     if (err) {


### PR DESCRIPTION
Here is the pull request for issue #9. I verified 2 i2c devices work on /dev/i2c-2 with this change.