### PR TITLE
Support user specified I2C bus. Fixes gh-11

### DIFF
--- a/lib/chip-io.js
+++ b/lib/chip-io.js
@@ -11,6 +11,7 @@ var PCF8574A = require('./pcf8574a');
 var pins = require('./pins');
 
 var TICK_INTERVAL = 19;
+var addressToBus = {};
 
 function ChipIO() {
   // call super constructor
@@ -176,8 +177,15 @@ ChipIO.prototype.digitalRead = function(pin, handler) {
   return this;
 };
 
-ChipIO.prototype.i2cConfig = function(delay) {
-  debug('i2cConfig', delay);
+ChipIO.prototype.i2cConfig = function(options) {
+  debug('i2cConfig', options);
+
+  // options.address is _always_ sent by all I2C component
+  // classes in Johnny-Five.
+  // If a bus was sent, then we need to associate the address to the bus.
+  if (options.bus && !Reflect.has(addressToBus, options.address)) {
+    addressToBus[options.address] = options.bus;
+  }
 
   return this;
 };
@@ -190,7 +198,8 @@ ChipIO.prototype.i2cWrite = function(address, register, data) {
 
   debug('i2cWrite', address, register, data);
 
-  var i2c = new I2C(1, address);
+  var bus = typeof addressToBus[address] !== undefined ? addressToBus[address] : 1;
+  var i2c = new I2C(bus, address);
 
   if (typeof(data) === 'number') {
     data = [data];
@@ -242,7 +251,8 @@ ChipIO.prototype.i2cReadOnce = function(address, register, size, handler) {
 
   debug('i2cReadOnce', address, register, size, handler);
 
-  var i2c = new I2C(1, address);
+  var bus = typeof addressToBus[address] !== undefined ? addressToBus[address] : 1;
+  var i2c = new I2C(bus, address);
 
   i2c.open(function(err) {
     if (err) {


### PR DESCRIPTION
This will make use of forwarded I2C options, eg.

```js
  var a = new five.Servo({
    bus: 1,
    address: 0x40,
    controller: "PCA9685",
    pin: 0,
  });
```
Signed-off-by: Rick Waldron <waldron.rick@gmail.com>