### PR TITLE
Use digitalWrite mode for PWM0 when values are 0 and 255

### DIFF
--- a/lib/allwinner-r8.js
+++ b/lib/allwinner-r8.js
@@ -102,9 +102,13 @@ AllwinnerR8.prototype.pinMode = function(pin, mode) {
     this._writeRegister(cfgReg, cfgVal);
   }
 
-  if (pin === 'PWM0' && mode === 2) {
-    var pwmCtrlVal = (1 << 6) | (1 << 5) | (1 << 4);
+  if (pin === 'PWM0') {
+    var pwmCtrlVal = 0;
     var pwmPeriodVal = (0xff << 16) | 0;
+
+    if (mode === 2) {
+      pwmCtrlVal = (1 << 6) | (1 << 5) | (1 << 4);
+    }
 
     this._writeRegister(PWM_CH0_PERIOD, pwmPeriodVal);
     this._writeRegister(PWM_CTRL, pwmCtrlVal);
@@ -113,9 +117,18 @@ AllwinnerR8.prototype.pinMode = function(pin, mode) {
 
 AllwinnerR8.prototype.pwmWrite = function(pin, value) {
   if (pin === 'PWM0') {
-    var pwmPeriodVal = (0xff << 16) | Math.round(value);
+    if (value === 0) {
+      this.pinMode('PWM0', 1);
+      this.digitalWrite('PWM0', 0);
+    } else if (value === 255) {
+      this.pinMode('PWM0', 1);
+      this.digitalWrite('PWM0', 1);
+    } else {
+      var pwmPeriodVal = (0xff << 16) | Math.round(value);
 
-    this._writeRegister(PWM_CH0_PERIOD, pwmPeriodVal);
+      this.pinMode('PWM0', 2);
+      this._writeRegister(PWM_CH0_PERIOD, pwmPeriodVal);
+    }
   }
 };
 


### PR DESCRIPTION
Fixes #24.

Can be tested via `npm install sandeepmistry/chip-io#pwm-fixes`.