### PR TITLE
update pins.json so the VCC-1V8 pin can be read as analog. Updated ax…

### DIFF
--- a/lib/axp209.js
+++ b/lib/axp209.js
@@ -22,9 +22,6 @@ util.inherits(AXP209, events.EventEmitter);
 
 AXP209.prototype.open = function() {
   this._i2c.open();
-  
-  this._configureVcc18Adc();
-  //this._resetVcc18();
 };
 
 AXP209.prototype.pinMode = function(pin, mode) {
@@ -33,6 +30,7 @@ AXP209.prototype.pinMode = function(pin, mode) {
   }
   if (pin === 'VCC-1V8' && mode === 2) {
       this._configureVcc18Adc();
+      //this._resetVcc18();
   }
 };
 

--- a/lib/axp209.js
+++ b/lib/axp209.js
@@ -15,12 +15,16 @@ function AXP209(bus, address) {
   this._i2c = new I2C(bus, address);
 
   this._reads = {};
+  
 }
 
 util.inherits(AXP209, events.EventEmitter);
 
 AXP209.prototype.open = function() {
   this._i2c.open();
+  
+  this._configureVcc18Adc();
+  //this._resetVcc18();
 };
 
 AXP209.prototype.pinMode = function(pin, mode) {
@@ -61,6 +65,12 @@ AXP209.prototype.tick = function() {
 
     this.emit('digital-read', 'BTN', button);
   }
+  
+  if (this._reads['VCC-1V8']) {
+    var vcc1v8AdcVolt = this._readVcc18Adc();
+
+    this.emit('analog-read', 'VCC-1V8', vcc1v8AdcVolt);
+  }
 };
 
 AXP209.prototype.close = function() {
@@ -85,9 +95,36 @@ AXP209.prototype._readButton = function() {
   return (value ? 1 : 0);
 };
 
+AXP209.prototype._readVcc18Adc = function() {
+  // enable 12-bit ADC for VCC 1.8 
+  var p = this._i2c.readRegister(0x85, 1)[0]; // 0-2v range or .7 - 2.7v range?
+  var rhigh = this._i2c.readRegister(0x64, 1)[0].toString(16);
+  var rlow = this._i2c.readRegister(0x65, 1)[0].toString(16);
+  var r = parseInt(rhigh + rlow, 16);
+  
+  var voltage = (((r * 10000)/4096) * 2) + (p * 7000);
+  
+  return voltage;
+};
+
 AXP209.prototype._configureBatAdc = function() {
   // force ADC enable for battery voltage and current
   return this._i2c.writeRegister(BAT_ADC_REGISTER, new Buffer([0xc3]));
+};
+
+AXP209.prototype._configureVcc18Adc = function() {
+  // force enable 12-bit ADC for VCC 1.8 
+  this._i2c.writeRegister(0x83, new Buffer([0x80])); // disable ADC input on GPIO0
+  this._i2c.writeRegister(0x90, new Buffer([0x04])); // set GPIO0 to 12 bit ADC input
+  this._i2c.writeRegister(0x85, new Buffer([0x00])); // use 0x01 for ADC input range 0.7-2.7475v
+  this._i2c.writeRegister(0x83, new Buffer([0x88])); // enable ADC input on GPIO0
+};
+
+AXP209.prototype._resetVcc18 = function() {
+  // reset VCC 1.8 to normal operation
+  this._i2c.writeRegister(0x83, new Buffer([0x80])); // disable ADC input on GPIO0
+  this._i2c.writeRegister(0x90, new Buffer([0x03])); 
+  this._i2c.writeRegister(0x91, new Buffer([0x00])); // output voltage = 1.8v + high_4_bit(0x91) * 0.1v
 };
 
 AXP209.prototype._writeGpio2 = function(value) {

--- a/lib/axp209.js
+++ b/lib/axp209.js
@@ -31,6 +31,9 @@ AXP209.prototype.pinMode = function(pin, mode) {
   if (pin === 'BAT') {
     this._configureBatAdc();
   }
+  if (pin === 'VCC-1V8' && mode === 2) {
+      this._configureVcc18Adc();
+  }
 };
 
 AXP209.prototype.analogRead = function(pin) {
@@ -102,7 +105,7 @@ AXP209.prototype._readVcc18Adc = function() {
   var rlow = this._i2c.readRegister(0x65, 1)[0].toString(16);
   var r = parseInt(rhigh + rlow, 16);
   
-  var voltage = (((r * 10000)/4096) * 2) + (p * 7000);
+  var voltage = (((r * 10000)/4096) * 2) + (p * 7000); // voltage in millivolts
   
   return voltage;
 };

--- a/lib/pins.json
+++ b/lib/pins.json
@@ -50,10 +50,11 @@
   },
   {
     "name": "VCC-1V8",
-    "supportedModes": [],
+    "supportedModes": [2],
     "mode": -1,
     "report": 0,
-    "analogChannel": 127
+    "analogChannel": 127,
+    "chip": "AXP209"
   },
   {
     "name": "BAT",


### PR DESCRIPTION
Allow VCC-1V8 pin to be read as 12-bit ADC

Based on some great information here: https://bbs.nextthing.co/t/chips-internal-adc/2136/59

The LRADC pin on the CHIP only allows for 6-bit (0-63) resolution.  To allow for more precise reading, I've updated the axp209 controller so that if you request to read VCC-1V8 as analog, the axp209 tick will then call a special function to read the appropriate i2c register.

It will read 0 unless certain registers are written to allow for this.  This is done in the `_configureVcc18Adc` which is called in the AXP209 open.  I just put it there for testing, but it would be better if we could expose it somehow. 

This is not quite merge ready – need to figure out where to put the configure and reset calls.   I didn't do much, just ported over the information in the above linked nextthing thread :)

Also, if anyone has suggestions on the efficiency of this, please feel free to send PRs or comments.  I know we would want to keep the `tick` function as minimal as possible.   Note that even though I've added to this `tick` function, it will only attempt to read if you've requested that read,  for example like this:

```
var fsr = new five.Sensor({
      pin: "VCC-1V8"
  });
  fsr.on("data", function(value) {
      console.log(value);
  });
```

I've tested this with an actual FSR sensor and it works great.