### PR TITLE
Move johhny-five to dependencies from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/sandeepmistry/node-chip-io#readme",
   "devDependencies": {
-    "johnny-five": "^0.9.17",
     "jshint": "^2.9.1-rc2"
   },
   "dependencies": {
@@ -32,7 +31,8 @@
     "debug": "^2.2.0",
     "errno": "^0.1.4",
     "ffi": "^2.0.0",
-    "ref": "^1.3.2"
+    "ref": "^1.3.2",
+    "johnny-five": "^0.9.17"
   },
   "os": [
     "linux"


### PR DESCRIPTION
Move the dependency on johhny-five from to dependencies from devDependencies because it is always required for use, due to being referenced here https://github.com/sandeepmistry/node-chip-io/blob/master/lib/battery-voltage.js#L4 which is always required by https://github.com/sandeepmistry/node-chip-io/blob/master/index.js#L5

This change is needed for production installs, and also transitive installs for software that uses node-chip-io but does not use johhny-five.